### PR TITLE
Console - compaction edit

### DIFF
--- a/web-console/src/components/auto-form.scss
+++ b/web-console/src/components/auto-form.scss
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.auto-form {
+  .ace_scroller {
+    background-color: #212c36;
+  }
+}

--- a/web-console/src/components/filler.tsx
+++ b/web-console/src/components/filler.tsx
@@ -20,6 +20,8 @@ import { Button } from '@blueprintjs/core';
 import * as React from 'react';
 import classNames from 'classnames';
 import './filler.scss';
+import {parseJSONToString, parseStringToJSON, validJson} from "../utils";
+import AceEditor from "react-ace";
 
 
 export const IconNames = {
@@ -255,5 +257,65 @@ export class TagInput extends React.Component<TagInputProps, { stringValue: stri
       value={stringValue}
       onChange={this.handleChange}
     />;
+  }
+}
+
+interface JSONInputProps extends React.Props<any>{
+  onChange: (newValue: string) => void;
+  value: JSON;
+  updateErrors: ((newValue: string) => void)
+}
+
+interface JSONInputState{
+  stringValue: string;
+}
+
+export class JSONInput extends React.Component<JSONInputProps, JSONInputState> {
+  constructor(props: JSONInputProps) {
+    super(props);
+    this.state = {
+      stringValue: ""
+    }
+  }
+
+  componentDidMount(): void {
+    const { value } = this.props;
+    const stringValue = parseJSONToString(value);
+    this.setState({
+      stringValue: stringValue
+    })
+  }
+
+  render() {
+    const { onChange, updateErrors } = this.props;
+    const { stringValue } = this.state;
+    return <AceEditor
+      className={"bp3-fill"}
+      key={"hjson"}
+      mode={"hjson"}
+      theme="solarized_dark"
+      name="ace-editor"
+      onChange={(e: string) => {
+        this.setState({stringValue: e});
+        if(validJson(e) || e === "") onChange(e);
+        updateErrors(e);
+      }}
+      focus={true}
+      fontSize={12}
+      width={'100%'}
+      height={"8vh"}
+      showPrintMargin={false}
+      showGutter={false}
+      value={stringValue}
+      editorProps={{
+        $blockScrolling: Infinity
+      }}
+      setOptions={{
+        enableBasicAutocompletion: false,
+        enableLiveAutocompletion: false,
+        showLineNumbers: false,
+        tabSize: 2,
+      }}
+    />
   }
 }

--- a/web-console/src/dialogs/compaction-dialog.scss
+++ b/web-console/src/dialogs/compaction-dialog.scss
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.compaction-dialog {
+  top: 8%;
+
+  .auto-form {
+    margin: 10px 15px;
+    padding: 0 5px 0 5px;
+    max-height: 70vh;
+    overflow: scroll;
+
+    .bp3-form-group {
+      padding: 0 15px;
+      margin: 0 0 5px;
+    }
+  ;
+
+    .bp3-html-select {
+      width: 195px;
+    }
+  }
+}

--- a/web-console/src/dialogs/compaction-dialog.tsx
+++ b/web-console/src/dialogs/compaction-dialog.tsx
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import { AutoForm } from '../components/auto-form';
+import './compaction-dialog.scss';
+import {Button, Classes, Dialog, Intent} from "@blueprintjs/core";
+
+export interface CompactionDialogProps extends React.Props<any> {
+  onClose: () => void,
+  onSave: (config: any) => void,
+  onDelete: () => void,
+  datasource: string,
+  configData: any,
+}
+
+export interface CompactionDialogState {
+  currentConfig: Record<string, any> | null;
+  JSONErrors: Record<string, boolean> | null;
+}
+
+export class CompactionDialog extends React.Component<CompactionDialogProps, CompactionDialogState> {
+  constructor(props: CompactionDialogProps) {
+    super(props);
+    this.state = {
+      currentConfig: null,
+      JSONErrors: null
+    };
+  }
+
+  componentDidMount(): void {
+    const { datasource, configData } = this.props;
+    let config: Record<string, any> = {
+      dataSource: datasource,
+      inputSegmentSizeBytes: 419430400,
+      keepSegmentGranularity: true,
+      maxNumSegmentsToCompact: 150,
+      skipOffsetFromLatest: "P1D",
+      targetCompactionSizeBytes: 419430400,
+      taskContext: null,
+      taskPriority: 25,
+      tuningConfig: null
+    };
+    if (configData !== undefined) {
+      config = configData;
+    }
+    this.setState({
+      currentConfig: config
+    });
+  }
+
+  render() {
+    const { onClose, onSave, onDelete, datasource, configData } = this.props;
+    const { currentConfig, JSONErrors } = this.state;
+    return <Dialog
+      className="compaction-dialog"
+      isOpen
+      onClose={ onClose }
+      canOutsideClickClose={false}
+      title={`Compaction config: ${datasource}`}
+    >
+      <AutoForm
+        fields={[
+          {
+            name: "inputSegmentSizeBytes",
+            type: "number"
+          },
+          {
+            name: "keepSegmentGranularity",
+            type: "boolean"
+          },
+          {
+            name: "maxNumSegmentsToCompact",
+            type: "number"
+          },
+          {
+            name: "skipOffsetFromLatest",
+            type: "string"
+          },
+          {
+            name: "targetCompactionSizeBytes",
+            type: "number"
+          },
+          {
+            name: "taskContext",
+            type: "json"
+          },
+          {
+            name: "taskPriority",
+            type: "number"
+          },
+          {
+            name: "tuningConfig",
+            type: "json"
+          }
+        ]}
+        model={currentConfig}
+        onChange={m => this.setState({currentConfig: m})}
+        updateJSONErrors={e => this.setState({JSONErrors: e})}
+        JSONErrors={JSONErrors}
+      />
+      <div className={Classes.DIALOG_FOOTER}>
+        <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+          <Button
+            text="Delete"
+            intent={Intent.DANGER}
+            onClick={onDelete}
+            disabled={configData === undefined}
+          />
+          <Button
+            text="Close"
+            onClick={onClose}
+          />
+          <Button
+            text="Submit"
+            intent={Intent.PRIMARY}
+            onClick={() => onSave(currentConfig)}
+            disabled={ currentConfig === null || (JSONErrors != null && !Object.keys(JSONErrors).every(e => JSONErrors[e] === true))}
+          />
+        </div>
+      </div>
+    </Dialog>
+  }
+}

--- a/web-console/src/utils/general.tsx
+++ b/web-console/src/utils/general.tsx
@@ -137,3 +137,32 @@ export function localStorageGet(key: string): string | null {
   if (typeof localStorage === 'undefined') return null;
   return localStorage.getItem(key);
 }
+
+// ----------------------------
+
+export function validJson(json: string): boolean {
+  try {
+    JSON.parse(json);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+// parse JSON to string; if JSON is null, parse empty string ""
+export function parseJSONToString(item: JSON): string {
+  if (item != null) {
+    return JSON.stringify(item, null, 2);
+  } else {
+    return "";
+  }
+}
+
+// parse string to JSON object; if string is empty, return null
+export function parseStringToJSON(s: string): JSON | null {
+  if (s === "") {
+    return null;
+  } else {
+    return JSON.parse(s);
+  }
+}

--- a/web-console/src/views/datasource-view.tsx
+++ b/web-console/src/views/datasource-view.tsx
@@ -18,26 +18,27 @@
 
 import axios from 'axios';
 import * as React from 'react';
-import * as classNames from 'classnames';
-import ReactTable from "react-table";
-import { Filter } from "react-table";
-import { Button, Intent, Switch } from "@blueprintjs/core";
-import { IconNames } from "../components/filler";
-import { AppToaster } from '../singletons/toaster';
-import { RuleEditor } from '../components/rule-editor';
-import { AsyncActionDialog } from '../dialogs/async-action-dialog';
-import { RetentionDialog } from '../dialogs/retention-dialog';
+import ReactTable, {Filter} from "react-table";
+import {Button, Intent, Switch} from "@blueprintjs/core";
+import {IconNames} from "../components/filler";
+import {AppToaster} from '../singletons/toaster';
+import {RuleEditor} from '../components/rule-editor';
+import {AsyncActionDialog} from '../dialogs/async-action-dialog';
+import {RetentionDialog} from '../dialogs/retention-dialog';
 import {
   addFilter,
-  formatNumber,
-  formatBytes,
   countBy,
+  formatBytes,
+  formatNumber,
+  getDruidErrorMessage,
   lookupBy,
-  QueryManager,
-  pluralIfNeeded, queryDruidSql, getDruidErrorMessage
+  pluralIfNeeded,
+  queryDruidSql,
+  QueryManager
 } from "../utils";
 
 import "./datasource-view.scss";
+import {CompactionDialog} from "../dialogs/compaction-dialog";
 
 export interface DatasourcesViewProps extends React.Props<any> {
   goToSql: (initSql: string) => void;
@@ -60,6 +61,7 @@ export interface DatasourcesViewState {
 
   showDisabled: boolean;
   retentionDialogOpenOn: { datasource: string, rules: any[] } | null;
+  compactionDialogOpenOn: {datasource: string, configData: any} | null;
   dropDataDatasource: string | null;
   enableDatasource: string | null;
   killDatasource: string | null;
@@ -94,6 +96,7 @@ export class DatasourcesView extends React.Component<DatasourcesViewProps, Datas
 
       showDisabled: false,
       retentionDialogOpenOn: null,
+      compactionDialogOpenOn: null,
       dropDataDatasource: null,
       enableDatasource: null,
       killDatasource: null
@@ -271,6 +274,45 @@ GROUP BY 1`);
     }, 50);
   }
 
+
+  private saveCompaction = async (compactionConfig: any) => {
+    if (compactionConfig === null) return;
+    try {
+      await axios.post(`/druid/coordinator/v1/config/compaction`, compactionConfig);
+      this.setState({compactionDialogOpenOn: null});
+      this.datasourceQueryManager.rerunLastQuery();
+    } catch (e) {
+      AppToaster.show({
+        message: e,
+        intent: Intent.DANGER
+      })
+    }
+  }
+
+  private deleteCompaction = async () => {
+    const {compactionDialogOpenOn} = this.state;
+    if (compactionDialogOpenOn === null) return;
+    const datasource = compactionDialogOpenOn.datasource;
+    AppToaster.show({
+      message: `Are you sure you want to delete ${datasource}'s compaction?`,
+      intent: Intent.DANGER,
+      action: {
+        text: "Confirm",
+        onClick: async () => {
+          try {
+            await axios.delete(`/druid/coordinator/v1/config/compaction/${datasource}`);
+            this.setState({compactionDialogOpenOn: null}, ()=>this.datasourceQueryManager.rerunLastQuery());
+          } catch (e) {
+            AppToaster.show({
+              message: e,
+              intent: Intent.DANGER
+            })
+          }
+        }
+      }
+    });
+  }
+
   renderRetentionDialog() {
     const { retentionDialogOpenOn, tiers } = this.state;
     if (!retentionDialogOpenOn) return null;
@@ -283,6 +325,20 @@ GROUP BY 1`);
       onCancel={() => this.setState({ retentionDialogOpenOn: null })}
       onSave={this.saveRules}
     />;
+  }
+
+  renderCompactionDialog() {
+    const { datasources, compactionDialogOpenOn } = this.state;
+
+    if (!compactionDialogOpenOn || !datasources) return;
+
+    return <CompactionDialog
+      datasource={compactionDialogOpenOn.datasource}
+      configData={compactionDialogOpenOn.configData}
+      onClose={() => this.setState({compactionDialogOpenOn: null})}
+      onSave={this.saveCompaction}
+      onDelete={this.deleteCompaction}
+    />
   }
 
   renderDatasourceTable() {
@@ -376,14 +432,15 @@ GROUP BY 1`);
             Cell: row => {
               const { compaction } = row.original;
               let text: string;
+              let compactionOpenOn: {datasource: string, configData: any} | null =
+                {datasource:row.original.datasource, configData: compaction};
               if (compaction) {
                 text = `Target: ${formatBytes(compaction.targetCompactionSizeBytes)}`;
               } else {
                 text = 'None';
               }
-              return <span>{text} <a onClick={() => alert('ToDo')}>&#x270E;</a></span>;
-            },
-            show: false // This feature is not ready, it will be enabled later
+              return <span>{text} <a onClick={() => this.setState({compactionDialogOpenOn: compactionOpenOn})}>&#x270E;</a></span>;
+            }
           },
           {
             Header: 'Size',
@@ -428,6 +485,7 @@ GROUP BY 1`);
       {this.renderEnableAction()}
       {this.renderKillAction()}
       {this.renderRetentionDialog()}
+      {this.renderCompactionDialog()}
     </>;
   }
 


### PR DESCRIPTION
The compaction dialog is implemented in order to allow users to add and edit the compaction configuration for each data source, where they could specify input segment size bytes. maximum number of segments to compact and etc..

- If the compaction configuration is already set, users could edit or delete the configuration through the dialog
<img src="https://user-images.githubusercontent.com/29443129/54158910-e68df180-4408-11e9-905c-f53ccb06db97.png" alt="t" width="260px" height="400px">

- If the compaction configuration has not been set yet, the dialog will load the default values for every property and the user can make the changes.
<img src="https://user-images.githubusercontent.com/29443129/54158983-12a97280-4409-11e9-9ce3-2a1a64cf43aa.png" alt="t" width="260px" height="400px">

- Two fields `Task context` and `Tuning config` require users to input either nothing at all or valid JSON representation before they can submit the configuration