### PR TITLE
LightPool

### DIFF
--- a/benchmarks/src/main/java/org/apache/druid/benchmark/query/lookup/TopnLookupBenchmark.java
+++ b/benchmarks/src/main/java/org/apache/druid/benchmark/query/lookup/TopnLookupBenchmark.java
@@ -29,7 +29,7 @@ import org.apache.druid.benchmark.datagen.BenchmarkDataGenerator;
 import org.apache.druid.benchmark.datagen.BenchmarkSchemaInfo;
 import org.apache.druid.benchmark.datagen.BenchmarkSchemas;
 import org.apache.druid.benchmark.query.QueryBenchmarkUtil;
-import org.apache.druid.collections.StoreReaderPool;
+import org.apache.druid.collections.LightPool;
 import org.apache.druid.collections.StupidPool;
 import org.apache.druid.data.input.InputRow;
 import org.apache.druid.hll.HyperLogLogHash;
@@ -95,10 +95,6 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
-import org.openjdk.jmh.runner.Runner;
-import org.openjdk.jmh.runner.RunnerException;
-import org.openjdk.jmh.runner.options.Options;
-import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.io.File;
 import java.io.IOException;
@@ -191,7 +187,7 @@ public class TopnLookupBenchmark
       stringMap.put(key, value);
     }
 
-    StoreReaderPool readerPool = new StoreReaderPool(new StoreReaderGenerator("lookup.paldb"), 2);
+    LightPool<StoreReader> readerPool = new LightPool<>(new StoreReaderGenerator("lookup.paldb"));
     reader = PalDB.createReader(new File("lookup.paldb"));
     LookupExtractor paldbExtractor = new PaldbLookupExtractor(readerPool, 0);
     LookupExtractor mapExtractor = new MapLookupExtractor(stringMap, false);

--- a/extensions-core/paldb-lookup/src/main/java/org/apache/druid/query/lookup/PaldbLookupExtractorFactory.java
+++ b/extensions-core/paldb-lookup/src/main/java/org/apache/druid/query/lookup/PaldbLookupExtractorFactory.java
@@ -25,7 +25,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
-import org.apache.druid.collections.StoreReaderPool;
+import com.linkedin.paldb.api.StoreReader;
+import org.apache.druid.collections.LightPool;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.logger.Logger;
 import org.apache.druid.query.DruidProcessingConfig;
@@ -48,7 +49,7 @@ public class PaldbLookupExtractorFactory implements LookupExtractorFactory
   private final String filepath;
   @JsonProperty
   private final int index;
-  private StoreReaderPool readerPool;
+  private LightPool<StoreReader> readerPool;
   private final ReadWriteLock startStopSync = new ReentrantReadWriteLock();
   private final AtomicBoolean started = new AtomicBoolean(false);
   private final DruidProcessingConfig processingConfig;
@@ -97,7 +98,7 @@ public class PaldbLookupExtractorFactory implements LookupExtractorFactory
       try {
         if (!started.get()) {
           LOG.info("starting paldb lookup");
-          readerPool = new StoreReaderPool(new StoreReaderGenerator(filepath), processingConfig.getNumThreads());
+          readerPool = new LightPool<>(new StoreReaderGenerator(filepath));
           started.set(true);
         }
         return started.get();

--- a/extensions-core/paldb-lookup/src/test/java/org/apache/druid/query/lookup/PaldbLookupTest.java
+++ b/extensions-core/paldb-lookup/src/test/java/org/apache/druid/query/lookup/PaldbLookupTest.java
@@ -20,8 +20,9 @@
 package org.apache.druid.query.lookup;
 
 import com.linkedin.paldb.api.PalDB;
+import com.linkedin.paldb.api.StoreReader;
 import com.linkedin.paldb.api.StoreWriter;
-import org.apache.druid.collections.StoreReaderPool;
+import org.apache.druid.collections.LightPool;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -48,7 +49,7 @@ public class PaldbLookupTest
     writer.put("foo1", new String[]{"baz"});
     writer.put("bat", new String[]{"abc", "xyz"});
     writer.close();
-    StoreReaderPool readerPool = new StoreReaderPool(new StoreReaderGenerator("store.paldb"), 2);
+    LightPool<StoreReader> readerPool = new LightPool<>(new StoreReaderGenerator("store.paldb"));
     paldbLookup = new PaldbLookupExtractor(readerPool, 0);
   }
 


### PR DESCRIPTION
- Switch from DefaultBlockingPool to LightPool in attempt to reduce overhead. Benchmarks show DBP on a single thread can do 1–2 million ops/sec, LightPool can do 30 million ops/sec. I didn't try multithreaded benchmarks but I think LightPool would pull even farther ahead.
- PaldbLookupExtractor: Removed `LOG.error("Contents of the row %s", Arrays.toString(arr))` statement, since `arr` would always be null at that line.
- PaldbLookupExtractor: Added `// TODO: Must have legitimate cache key` comment to getCacheKey