### PR TITLE
[Backport] Fail superbatch range partition multi dim values (#9058)

### DIFF
--- a/docs/ingestion/native-batch.md
+++ b/docs/ingestion/native-batch.md
@@ -268,7 +268,7 @@ The three `partitionsSpec` types have different pros and cons:
 |property|description|default|required?|
 |--------|-----------|-------|---------|
 |type|This should always be `single_dim`|none|yes|
-|partitionDimension|The dimension to partition on. Only rows with a single dimension value will be included.|none|yes|
+|partitionDimension|The dimension to partition on. Only rows with a single dimension value are allowed.|none|yes|
 |targetRowsPerSegment|Target number of rows to include in a partition, should be a number that targets segments of 500MB\~1GB.|none|either this or `maxRowsPerSegment`|
 |maxRowsPerSegment|Maximum number of rows to include in a partition. Defaults to 50% larger than the `targetRowsPerSegment`.|none|either this or `targetRowsPerSegment`|
 |assumeGrouped|Assume that input data has already been grouped on time and dimensions. Ingestion will run faster, but may choose sub-optimal partitions if this assumption is violated.|false|no|

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/batch/parallel/PartialDimensionDistributionTaskTest.java
@@ -237,7 +237,7 @@ public class PartialDimensionDistributionTaskTest
     }
 
     @Test
-    public void skipsRowsWithMultipleDimensionValues()
+    public void failsIfRowHasMultipleDimensionValues()
     {
       InputSource inlineInputSource = new InlineInputSource(
           ParallelIndexTestingFactory.createRow(0, Arrays.asList("a", "b"))
@@ -245,10 +245,10 @@ public class PartialDimensionDistributionTaskTest
       PartialDimensionDistributionTaskBuilder taskBuilder = new PartialDimensionDistributionTaskBuilder()
           .inputSource(inlineInputSource);
 
-      DimensionDistributionReport report = runTask(taskBuilder);
+      exception.expect(RuntimeException.class);
+      exception.expectMessage("Cannot partition on multi-value dimension [dim]");
 
-      Map<Interval, StringDistribution> intervalToDistribution = report.getIntervalToDistribution();
-      Assert.assertEquals(0, intervalToDistribution.size());
+      runTask(taskBuilder);
     }
 
     @Test


### PR DESCRIPTION
Backport https://github.com/apache/incubator-druid/pull/9058 to 0.17.0-iap.

### Description

Change the behavior of parallel indexing range partitioning to fail ingestion if any row had multiple values for the partition dimension. After this change, the behavior matches that of hadoop indexing. (Previously, rows with multiple dimension values would be skipped.)

<hr>

This PR has:
- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths.