### PR TITLE
[Backport] fix build by updating kafka client to 2.2.2 for CVE-2019-12399

### DIFF
--- a/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
+++ b/extensions-core/kafka-extraction-namespace/src/test/java/org/apache/druid/query/lookup/TestKafkaExtractionCluster.java
@@ -205,7 +205,7 @@ public class TestKafkaExtractionCluster
 
   private void checkServer()
   {
-    if (!kafkaServer.apis().controller().isActive()) {
+    if (!kafkaServer.dataPlaneRequestProcessor().controller().isActive()) {
       throw new ISE("server is not active!");
     }
   }

--- a/extensions-core/kafka-indexing-service/pom.xml
+++ b/extensions-core/kafka-indexing-service/pom.xml
@@ -33,10 +33,6 @@
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
-  <properties>
-    <apache.kafka.version>2.2.1</apache.kafka.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.druid</groupId>

--- a/licenses.yaml
+++ b/licenses.yaml
@@ -3093,7 +3093,7 @@ libraries:
 ---
 
 name: Apache Kafka
-version: 2.2.1
+version: 2.2.2
 license_category: binary
 module: extensions/druid-kafka-indexing-service
 license_name: Apache License version 2.0
@@ -3102,7 +3102,7 @@ libraries:
 notices:
   - kafka-clients: |
       Apache Kafka
-      Copyright 2018 The Apache Software Foundation.
+      Copyright 2019 The Apache Software Foundation.
 
       This distribution has a binary dependency on jersey, which is available under the CDDL
       License. The source code of jersey can be found at https://github.com/jersey/jersey/.
@@ -3966,14 +3966,14 @@ name: Apache Kafka
 license_category: binary
 module: extensions/kafka-extraction-namespace
 license_name: Apache License version 2.0
-version: 2.1.1
+version: 2.2.2
 libraries:
   - org.apache.kafka: kafka_2.12
   - org.apache.kafka: kafka-clients
 notices:
   - kafka-clients:
       Apache Kafka
-      Copyright 2018 The Apache Software Foundation.
+      Copyright 2019 The Apache Software Foundation.
 
       This distribution has a binary dependency on jersey, which is available under the CDDL
       License. The source code of jersey can be found at https://github.com/jersey/jersey/.

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <aether.version>0.9.0.M2</aether.version>
         <apache.curator.version>4.1.0</apache.curator.version>
         <apache.curator.test.version>2.12.0</apache.curator.test.version>
-        <apache.kafka.version>2.1.1</apache.kafka.version>
+        <apache.kafka.version>2.2.2</apache.kafka.version>
         <avatica.version>1.15.0</avatica.version>
         <avro.version>1.9.1</avro.version>
         <calcite.version>1.21.0</calcite.version>


### PR DESCRIPTION
Backport of https://github.com/apache/druid/pull/9259