### PR TITLE
[Backport] disable union query result level caching

### DIFF
--- a/processing/src/main/java/org/apache/druid/query/DataSource.java
+++ b/processing/src/main/java/org/apache/druid/query/DataSource.java
@@ -35,5 +35,13 @@ import java.util.List;
               })
 public interface DataSource
 {
+  /**
+   * Returns the names of all table datasources involved in this query.
+   */
   List<String> getNames();
+
+  /**
+   * Returns true if queries on this dataSource are cacheable at both the result level and per-segment level.
+   */
+  boolean isCacheable();
 }

--- a/processing/src/main/java/org/apache/druid/query/QueryDataSource.java
+++ b/processing/src/main/java/org/apache/druid/query/QueryDataSource.java
@@ -43,6 +43,12 @@ public class QueryDataSource implements DataSource
     return query.getDataSource().getNames();
   }
 
+  @Override
+  public boolean isCacheable()
+  {
+    return false;
+  }
+
   @JsonProperty
   public Query getQuery()
   {

--- a/processing/src/main/java/org/apache/druid/query/TableDataSource.java
+++ b/processing/src/main/java/org/apache/druid/query/TableDataSource.java
@@ -51,6 +51,12 @@ public class TableDataSource implements DataSource
   }
 
   @Override
+  public boolean isCacheable()
+  {
+    return true;
+  }
+
+  @Override
   public String toString()
   {
     return name;

--- a/processing/src/main/java/org/apache/druid/query/UnionDataSource.java
+++ b/processing/src/main/java/org/apache/druid/query/UnionDataSource.java
@@ -46,6 +46,16 @@ public class UnionDataSource implements DataSource
     return dataSources.stream().map(input -> Iterables.getOnlyElement(input.getNames())).collect(Collectors.toList());
   }
 
+  @Override
+  public boolean isCacheable()
+  {
+    // Disables result-level caching for 'union' datasources, which doesn't work currently.
+    // See https://github.com/apache/druid/issues/8713 for reference.
+    // Note that per-segment caching is still effective, since at the time the per-segment cache evaluates a query
+    // for cacheability, it would have already been rewritten to a query on a single table.
+    return false;
+  }
+
   @JsonProperty
   public List<TableDataSource> getDataSources()
   {

--- a/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
+++ b/server/src/main/java/org/apache/druid/client/CachingClusteredClient.java
@@ -241,8 +241,8 @@ public class CachingClusteredClient implements QuerySegmentWalker
       this.toolChest = warehouse.getToolChest(query);
       this.strategy = toolChest.getCacheStrategy(query);
 
-      this.useCache = CacheUtil.useCacheOnBrokers(query, strategy, cacheConfig);
-      this.populateCache = CacheUtil.populateCacheOnBrokers(query, strategy, cacheConfig);
+      this.useCache = CacheUtil.isUseSegmentCache(query, strategy, cacheConfig, CacheUtil.ServerType.BROKER);
+      this.populateCache = CacheUtil.isPopulateSegmentCache(query, strategy, cacheConfig, CacheUtil.ServerType.BROKER);
       this.isBySegment = QueryContexts.isBySegment(query);
       // Note that enabling this leads to putting uncovered intervals information in the response headers
       // and might blow up in some cases https://github.com/apache/druid/issues/2108

--- a/server/src/main/java/org/apache/druid/client/CachingQueryRunner.java
+++ b/server/src/main/java/org/apache/druid/client/CachingQueryRunner.java
@@ -77,8 +77,13 @@ public class CachingQueryRunner<T> implements QueryRunner<T>
   {
     Query<T> query = queryPlus.getQuery();
     final CacheStrategy strategy = toolChest.getCacheStrategy(query);
-    final boolean populateCache = CacheUtil.populateCacheOnDataNodes(query, strategy, cacheConfig);
-    final boolean useCache = CacheUtil.useCacheOnDataNodes(query, strategy, cacheConfig);
+    final boolean populateCache = CacheUtil.isPopulateSegmentCache(
+        query,
+        strategy,
+        cacheConfig,
+        CacheUtil.ServerType.DATA
+    );
+    final boolean useCache = CacheUtil.isUseSegmentCache(query, strategy, cacheConfig, CacheUtil.ServerType.DATA);
 
     final Cache.NamedKey key;
     if (strategy != null && (useCache || populateCache)) {

--- a/server/src/test/java/org/apache/druid/client/CacheUtilTest.java
+++ b/server/src/test/java/org/apache/druid/client/CacheUtilTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.client;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.druid.client.cache.CacheConfig;
+import org.apache.druid.java.util.common.granularity.Granularities;
+import org.apache.druid.query.CacheStrategy;
+import org.apache.druid.query.Druids;
+import org.apache.druid.query.Query;
+import org.apache.druid.query.timeseries.TimeseriesQuery;
+import org.apache.druid.segment.TestHelper;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class CacheUtilTest
+{
+  private final TimeseriesQuery timeseriesQuery =
+      Druids.newTimeseriesQueryBuilder()
+            .dataSource("foo")
+            .intervals("2000/3000")
+            .granularity(Granularities.ALL)
+            .build();
+
+  @Test
+  public void test_isQueryCacheable_cacheableOnBroker()
+  {
+    Assert.assertTrue(
+        CacheUtil.isQueryCacheable(
+            timeseriesQuery,
+            new DummyCacheStrategy<>(true, true),
+            makeCacheConfig(ImmutableMap.of()),
+            CacheUtil.ServerType.BROKER
+        )
+    );
+  }
+
+  @Test
+  public void test_isQueryCacheable_cacheableOnDataServer()
+  {
+    Assert.assertTrue(
+        CacheUtil.isQueryCacheable(
+            timeseriesQuery,
+            new DummyCacheStrategy<>(true, true),
+            makeCacheConfig(ImmutableMap.of()),
+            CacheUtil.ServerType.DATA
+        )
+    );
+  }
+
+  @Test
+  public void test_isQueryCacheable_unCacheableOnBroker()
+  {
+    Assert.assertFalse(
+        CacheUtil.isQueryCacheable(
+            timeseriesQuery,
+            new DummyCacheStrategy<>(false, true),
+            makeCacheConfig(ImmutableMap.of()),
+            CacheUtil.ServerType.BROKER
+        )
+    );
+  }
+
+  @Test
+  public void test_isQueryCacheable_unCacheableOnDataServer()
+  {
+    Assert.assertFalse(
+        CacheUtil.isQueryCacheable(
+            timeseriesQuery,
+            new DummyCacheStrategy<>(true, false),
+            makeCacheConfig(ImmutableMap.of()),
+            CacheUtil.ServerType.DATA
+        )
+    );
+  }
+
+  @Test
+  public void test_isQueryCacheable_unCacheableType()
+  {
+    Assert.assertFalse(
+        CacheUtil.isQueryCacheable(
+            timeseriesQuery,
+            new DummyCacheStrategy<>(true, false),
+            makeCacheConfig(ImmutableMap.of("unCacheable", ImmutableList.of("timeseries"))),
+            CacheUtil.ServerType.BROKER
+        )
+    );
+  }
+
+  @Test
+  public void test_isQueryCacheable_nullCacheStrategy()
+  {
+    Assert.assertFalse(
+        CacheUtil.isQueryCacheable(
+            timeseriesQuery,
+            null,
+            makeCacheConfig(ImmutableMap.of()),
+            CacheUtil.ServerType.BROKER
+        )
+    );
+  }
+
+  private static CacheConfig makeCacheConfig(final Map<String, Object> properties)
+  {
+    return TestHelper.makeJsonMapper().convertValue(properties, CacheConfig.class);
+  }
+
+  private static class DummyCacheStrategy<T, CacheType, QueryType extends Query<T>>
+      implements CacheStrategy<T, CacheType, QueryType>
+  {
+    private final boolean cacheableOnBrokers;
+    private final boolean cacheableOnDataServers;
+
+    public DummyCacheStrategy(boolean cacheableOnBrokers, boolean cacheableOnDataServers)
+    {
+      this.cacheableOnBrokers = cacheableOnBrokers;
+      this.cacheableOnDataServers = cacheableOnDataServers;
+    }
+
+    @Override
+    public boolean isCacheable(QueryType query, boolean willMergeRunners)
+    {
+      return willMergeRunners ? cacheableOnDataServers : cacheableOnBrokers;
+    }
+
+    @Override
+    public byte[] computeCacheKey(QueryType query)
+    {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public byte[] computeResultLevelCacheKey(QueryType query)
+    {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TypeReference<CacheType> getCacheObjectClazz()
+    {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Function<T, CacheType> prepareForCache(boolean isResultLevelCache)
+    {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Function<CacheType, T> pullFromCache(boolean isResultLevelCache)
+    {
+      throw new UnsupportedOperationException();
+    }
+  }
+}


### PR DESCRIPTION
Performs backport surgery to get some cache stuff from https://github.com/apache/druid/pull/9235 to avoid the issue described in https://github.com/apache/druid/issues/8713