### PR TITLE
[Backport] Upgrade netty 4 to fix CVE-2020-11612 (#9651)

### DIFF
--- a/licenses.yaml
+++ b/licenses.yaml
@@ -793,7 +793,7 @@ name: Netty
 license_category: binary
 module: java-core
 license_name: Apache License version 2.0
-version: 4.1.45.Final
+version: 4.1.48.Final
 libraries:
   - io.netty: netty-buffer
   - io.netty: netty-codec

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <log4j.version>2.8.2</log4j.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <!-- Spark updated in https://github.com/apache/spark/pull/19884 -->
-        <netty4.version>4.1.45.Final</netty4.version>
+        <netty4.version>4.1.48.Final</netty4.version>
         <node.version>v10.14.2</node.version>
         <npm.version>6.5.0</npm.version>
         <protobuf.version>3.11.0</protobuf.version>


### PR DESCRIPTION
Backport https://github.com/apache/druid/pull/9651 to 0.17.0-iap