### PR TITLE
[Backport] Fails creation of TaskResource if availabilityGroup is null

### DIFF
--- a/indexing-service/src/main/java/org/apache/druid/indexing/common/task/TaskResource.java
+++ b/indexing-service/src/main/java/org/apache/druid/indexing/common/task/TaskResource.java
@@ -21,6 +21,7 @@ package org.apache.druid.indexing.common.task;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 
 /**
  */
@@ -35,7 +36,8 @@ public class TaskResource
       @JsonProperty("requiredCapacity") int requiredCapacity
   )
   {
-    this.availabilityGroup = availabilityGroup;
+    this.availabilityGroup = Preconditions.checkNotNull(availabilityGroup, "availabilityGroup");
+    Preconditions.checkArgument(requiredCapacity > 0);
     this.requiredCapacity = requiredCapacity;
   }
 

--- a/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/common/task/TaskSerdeTest.java
@@ -186,6 +186,48 @@ public class TaskSerdeTest
   }
 
   @Test
+  public void testTaskResourceValid() throws Exception
+  {
+    TaskResource actual = jsonMapper.readValue(
+        "{\"availabilityGroup\":\"index_xxx_mmm\", \"requiredCapacity\":1}",
+        TaskResource.class
+    );
+    Assert.assertNotNull(actual);
+    Assert.assertNotNull(actual.getAvailabilityGroup());
+    Assert.assertTrue(actual.getRequiredCapacity() > 0);
+  }
+
+  @Test
+  public void testTaskResourceWithNullAvailabilityGroupShouldFail() throws Exception
+  {
+    thrown.expectCause(CoreMatchers.isA(NullPointerException.class));
+    jsonMapper.readValue(
+        "{\"availabilityGroup\":null, \"requiredCapacity\":10}",
+        TaskResource.class
+    );
+  }
+
+  @Test
+  public void testTaskResourceWithZeroRequiredCapacityShouldFail() throws Exception
+  {
+    thrown.expectCause(CoreMatchers.isA(NullPointerException.class));
+    jsonMapper.readValue(
+        "{\"availabilityGroup\":null, \"requiredCapacity\":0}",
+        TaskResource.class
+    );
+  }
+
+  @Test
+  public void testTaskResourceWithNegativeRequiredCapacityShouldFail() throws Exception
+  {
+    thrown.expectCause(CoreMatchers.isA(NullPointerException.class));
+    jsonMapper.readValue(
+        "{\"availabilityGroup\":null, \"requiredCapacity\":-1}",
+        TaskResource.class
+    );
+  }
+
+  @Test
   public void testIndexTaskSerde() throws Exception
   {
     final IndexTask task = new IndexTask(


### PR DESCRIPTION
Clean backport of https://github.com/apache/druid/pull/9892