### PR TITLE
[0.19.0-iap] Fix sys.servers table to not throw NPE and handle brokers/indexers/peons properly for broadcast segments

### DIFF
--- a/core/src/main/java/org/apache/druid/indexer/TaskLocation.java
+++ b/core/src/main/java/org/apache/druid/indexer/TaskLocation.java
@@ -22,6 +22,7 @@ package org.apache.druid.indexer;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
 
 public class TaskLocation
@@ -44,7 +45,7 @@ public class TaskLocation
 
   @JsonCreator
   public TaskLocation(
-      @JsonProperty("host") String host,
+      @JsonProperty("host") @Nullable String host,
       @JsonProperty("port") int port,
       @JsonProperty("tlsPort") int tlsPort
   )
@@ -54,6 +55,7 @@ public class TaskLocation
     this.tlsPort = tlsPort;
   }
 
+  @Nullable
   @JsonProperty
   public String getHost()
   {

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/AbstractTestQueryHelper.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/AbstractTestQueryHelper.java
@@ -63,9 +63,23 @@ public abstract class AbstractTestQueryHelper<QueryResultType extends AbstractQu
     this.routerTLS = config.getRouterTLSUrl();
   }
 
-  public abstract void testQueriesFromFile(String filePath, int timesToRun) throws Exception;
-
   public abstract String getQueryURL(String schemeAndHost);
+
+  public void testQueriesFromFile(String filePath, int timesToRun) throws Exception
+  {
+    testQueriesFromFile(getQueryURL(broker), filePath, timesToRun);
+    testQueriesFromFile(getQueryURL(brokerTLS), filePath, timesToRun);
+    testQueriesFromFile(getQueryURL(router), filePath, timesToRun);
+    testQueriesFromFile(getQueryURL(routerTLS), filePath, timesToRun);
+  }
+
+  public void testQueriesFromString(String str, int timesToRun) throws Exception
+  {
+    testQueriesFromString(getQueryURL(broker), str, timesToRun);
+    testQueriesFromString(getQueryURL(brokerTLS), str, timesToRun);
+    testQueriesFromString(getQueryURL(router), str, timesToRun);
+    testQueriesFromString(getQueryURL(routerTLS), str, timesToRun);
+  }
 
   public void testQueriesFromFile(String url, String filePath, int timesToRun) throws Exception
   {

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/SqlTestQueryHelper.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/SqlTestQueryHelper.java
@@ -39,15 +39,6 @@ public class SqlTestQueryHelper extends AbstractTestQueryHelper<SqlQueryWithResu
   }
 
   @Override
-  public void testQueriesFromFile(String filePath, int timesToRun) throws Exception
-  {
-    testQueriesFromFile(getQueryURL(broker), filePath, timesToRun);
-    testQueriesFromFile(getQueryURL(brokerTLS), filePath, timesToRun);
-    testQueriesFromFile(getQueryURL(router), filePath, timesToRun);
-    testQueriesFromFile(getQueryURL(routerTLS), filePath, timesToRun);
-  }
-
-  @Override
   public String getQueryURL(String schemeAndHost)
   {
     return StringUtils.format("%s/druid/v2/sql", schemeAndHost);

--- a/integration-tests/src/main/java/org/apache/druid/testing/utils/TestQueryHelper.java
+++ b/integration-tests/src/main/java/org/apache/druid/testing/utils/TestQueryHelper.java
@@ -39,24 +39,6 @@ public class TestQueryHelper extends AbstractTestQueryHelper<QueryWithResults>
   }
 
   @Override
-  public void testQueriesFromFile(String filePath, int timesToRun) throws Exception
-  {
-    testQueriesFromFile(getQueryURL(broker), filePath, timesToRun);
-    testQueriesFromFile(getQueryURL(brokerTLS), filePath, timesToRun);
-    testQueriesFromFile(getQueryURL(router), filePath, timesToRun);
-    testQueriesFromFile(getQueryURL(routerTLS), filePath, timesToRun);
-  }
-
-  public void testQueriesFromString(String str, int timesToRun) throws Exception
-  {
-    testQueriesFromString(getQueryURL(broker), str, timesToRun);
-    testQueriesFromString(getQueryURL(brokerTLS), str, timesToRun);
-    testQueriesFromString(getQueryURL(router), str, timesToRun);
-    testQueriesFromString(getQueryURL(routerTLS), str, timesToRun);
-  }
-
-
-  @Override
   public String getQueryURL(String schemeAndHost)
   {
     return StringUtils.format("%s/druid/v2?pretty", schemeAndHost);

--- a/server/src/main/java/org/apache/druid/discovery/DiscoveryDruidNode.java
+++ b/server/src/main/java/org/apache/druid/discovery/DiscoveryDruidNode.java
@@ -21,7 +21,6 @@ package org.apache.druid.discovery;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.druid.client.DruidServer;
 import org.apache.druid.server.DruidNode;
 
 import java.util.HashMap;
@@ -39,8 +38,12 @@ public class DiscoveryDruidNode
   private final DruidNode druidNode;
   private final NodeRole nodeRole;
 
-  // Other metadata associated with the node e.g.
-  // if its a historical node then lookup information, segment loading capacity etc.
+  /**
+   * Other metadata associated with the node e.g.
+   * if it's a historical node then lookup information, segment loading capacity etc.
+   *
+   * @see DruidNodeDiscoveryProvider#SERVICE_TO_NODE_TYPES
+   */
   private final Map<String, DruidService> services = new HashMap<>();
 
   @JsonCreator
@@ -78,19 +81,6 @@ public class DiscoveryDruidNode
   public DruidNode getDruidNode()
   {
     return druidNode;
-  }
-
-  public DruidServer toDruidServer()
-  {
-    return new DruidServer(
-        getDruidNode().getHostAndPortToUse(),
-        getDruidNode().getHostAndPort(),
-        getDruidNode().getHostAndTlsPort(),
-        ((DataNodeService) getServices().get(DataNodeService.DISCOVERY_SERVICE_KEY)).getMaxSize(),
-        ((DataNodeService) getServices().get(DataNodeService.DISCOVERY_SERVICE_KEY)).getType(),
-        ((DataNodeService) getServices().get(DataNodeService.DISCOVERY_SERVICE_KEY)).getTier(),
-        ((DataNodeService) getServices().get(DataNodeService.DISCOVERY_SERVICE_KEY)).getPriority()
-    );
   }
 
   @Override

--- a/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
+++ b/sql/src/main/java/org/apache/druid/sql/calcite/schema/SystemSchema.java
@@ -49,12 +49,15 @@ import org.apache.druid.client.JsonParserIterator;
 import org.apache.druid.client.TimelineServerView;
 import org.apache.druid.client.coordinator.Coordinator;
 import org.apache.druid.client.indexing.IndexingService;
+import org.apache.druid.discovery.DataNodeService;
 import org.apache.druid.discovery.DiscoveryDruidNode;
 import org.apache.druid.discovery.DruidLeaderClient;
 import org.apache.druid.discovery.DruidNodeDiscoveryProvider;
+import org.apache.druid.discovery.DruidService;
 import org.apache.druid.discovery.NodeRole;
 import org.apache.druid.indexer.TaskStatusPlus;
 import org.apache.druid.indexing.overlord.supervisor.SupervisorStatus;
+import org.apache.druid.java.util.common.ISE;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.parsers.CloseableIterator;
 import org.apache.druid.java.util.http.client.Request;
@@ -121,10 +124,6 @@ public class SystemSchema extends AbstractSchema
   private static final long IS_AVAILABLE_TRUE = 1L;
   private static final long IS_OVERSHADOWED_FALSE = 0L;
   private static final long IS_OVERSHADOWED_TRUE = 1L;
-
-  //defaults for SERVERS table
-  private static final long MAX_SERVER_SIZE = 0L;
-  private static final long CURRENT_SERVER_SIZE = 0L;
 
   static final RowSignature SEGMENTS_SIGNATURE = RowSignature
       .builder()
@@ -211,14 +210,8 @@ public class SystemSchema extends AbstractSchema
   {
     Preconditions.checkNotNull(serverView, "serverView");
     BytesAccumulatingResponseHandler responseHandler = new BytesAccumulatingResponseHandler();
-    final SegmentsTable segmentsTable = new SegmentsTable(
-        druidSchema,
-        metadataView,
-        jsonMapper,
-        authorizerMapper
-    );
     this.tableMap = ImmutableMap.of(
-        SEGMENTS_TABLE, segmentsTable,
+        SEGMENTS_TABLE, new SegmentsTable(druidSchema, metadataView, authorizerMapper),
         SERVERS_TABLE, new ServersTable(druidNodeDiscoveryProvider, serverInventoryView, authorizerMapper),
         SERVER_SEGMENTS_TABLE, new ServerSegmentsTable(serverView, authorizerMapper),
         TASKS_TABLE, new TasksTable(overlordDruidLeaderClient, jsonMapper, responseHandler, authorizerMapper),
@@ -238,20 +231,17 @@ public class SystemSchema extends AbstractSchema
   static class SegmentsTable extends AbstractTable implements ScannableTable
   {
     private final DruidSchema druidSchema;
-    private final ObjectMapper jsonMapper;
     private final AuthorizerMapper authorizerMapper;
     private final MetadataSegmentView metadataView;
 
     public SegmentsTable(
         DruidSchema druidSchemna,
         MetadataSegmentView metadataView,
-        ObjectMapper jsonMapper,
         AuthorizerMapper authorizerMapper
     )
     {
       this.druidSchema = druidSchemna;
       this.metadataView = metadataView;
-      this.jsonMapper = jsonMapper;
       this.authorizerMapper = authorizerMapper;
     }
 
@@ -311,7 +301,7 @@ public class SystemSchema extends AbstractSchema
                 segment.getInterval().getEnd().toString(),
                 segment.getSize(),
                 segment.getVersion(),
-                Long.valueOf(segment.getShardSpec().getPartitionNum()),
+                (long) segment.getShardSpec().getPartitionNum(),
                 numReplicas,
                 numRows,
                 IS_PUBLISHED_TRUE, //is_published is true for published segments
@@ -369,8 +359,10 @@ public class SystemSchema extends AbstractSchema
         DataContext root
     )
     {
-      final AuthenticationResult authenticationResult =
-          (AuthenticationResult) root.get(PlannerContext.DATA_CTX_AUTHENTICATION_RESULT);
+      final AuthenticationResult authenticationResult = (AuthenticationResult) Preconditions.checkNotNull(
+          root.get(PlannerContext.DATA_CTX_AUTHENTICATION_RESULT),
+          "authenticationResult in dataContext"
+      );
 
       final Iterable<SegmentWithOvershadowedStatus> authorizedSegments = AuthorizationUtils
           .filterAuthorizedResources(
@@ -387,8 +379,10 @@ public class SystemSchema extends AbstractSchema
         DataContext root
     )
     {
-      final AuthenticationResult authenticationResult =
-          (AuthenticationResult) root.get(PlannerContext.DATA_CTX_AUTHENTICATION_RESULT);
+      final AuthenticationResult authenticationResult = (AuthenticationResult) Preconditions.checkNotNull(
+          root.get(PlannerContext.DATA_CTX_AUTHENTICATION_RESULT),
+          "authenticationResult in dataContext"
+      );
 
       Function<Entry<SegmentId, AvailableSegmentMetadata>, Iterable<ResourceAction>> raGenerator = segment ->
           Collections.singletonList(
@@ -455,6 +449,13 @@ public class SystemSchema extends AbstractSchema
    */
   static class ServersTable extends AbstractTable implements ScannableTable
   {
+    // This is used for maxSize and currentSize when they are unknown.
+    // The unknown size doesn't have to be 0, it's better to be null.
+    // However, this table is returning 0 for them for some reason and we keep the behavior for backwards compatibility.
+    // Maybe we can remove this and return nulls instead when we remove the bindable query path which is currently
+    // used to query system tables.
+    private static final long UNKNOWN_SIZE = 0L;
+
     private final AuthorizerMapper authorizerMapper;
     private final DruidNodeDiscoveryProvider druidNodeDiscoveryProvider;
     private final InventoryView serverInventoryView;
@@ -486,37 +487,121 @@ public class SystemSchema extends AbstractSchema
     public Enumerable<Object[]> scan(DataContext root)
     {
       final Iterator<DiscoveryDruidNode> druidServers = getDruidServers(druidNodeDiscoveryProvider);
-      final AuthenticationResult authenticationResult =
-          (AuthenticationResult) root.get(PlannerContext.DATA_CTX_AUTHENTICATION_RESULT);
-
+      final AuthenticationResult authenticationResult = (AuthenticationResult) Preconditions.checkNotNull(
+          root.get(PlannerContext.DATA_CTX_AUTHENTICATION_RESULT),
+          "authenticationResult in dataContext"
+      );
       checkStateReadAccessForServers(authenticationResult, authorizerMapper);
 
       final FluentIterable<Object[]> results = FluentIterable
           .from(() -> druidServers)
-          .transform((DiscoveryDruidNode val) -> {
-            boolean isDataNode = false;
-            final DruidNode node = val.getDruidNode();
-            long currHistoricalSize = 0;
-            if (val.getNodeRole().equals(NodeRole.HISTORICAL)) {
-              final DruidServer server = serverInventoryView.getInventoryValue(val.toDruidServer().getName());
-              currHistoricalSize = server.getCurrSize();
-              isDataNode = true;
+          .transform((DiscoveryDruidNode discoveryDruidNode) -> {
+            //noinspection ConstantConditions
+            final boolean isDiscoverableDataServer = isDiscoverableDataServer(discoveryDruidNode);
+
+            if (isDiscoverableDataServer) {
+              final DruidServer druidServer = serverInventoryView.getInventoryValue(
+                  discoveryDruidNode.getDruidNode().getHostAndPortToUse()
+              );
+              if (druidServer != null || discoveryDruidNode.getNodeRole().equals(NodeRole.HISTORICAL)) {
+                // Build a row for the data server if that server is in the server view, or the node type is historical.
+                // The historicals are usually supposed to be found in the server view. If some historicals are
+                // missing, it could mean that there are some problems in them to announce themselves. We just fill
+                // their status with nulls in this case.
+                return buildRowForDiscoverableDataServer(discoveryDruidNode, druidServer);
+              } else {
+                return buildRowForNonDataServer(discoveryDruidNode);
+              }
+            } else {
+              return buildRowForNonDataServer(discoveryDruidNode);
             }
-            return new Object[]{
-                node.getHostAndPortToUse(),
-                extractHost(node.getHost()),
-                (long) extractPort(node.getHostAndPort()),
-                (long) extractPort(node.getHostAndTlsPort()),
-                StringUtils.toLowerCase(toStringOrNull(val.getNodeRole())),
-                isDataNode ? val.toDruidServer().getTier() : null,
-                isDataNode ? currHistoricalSize : CURRENT_SERVER_SIZE,
-                isDataNode ? val.toDruidServer().getMaxSize() : MAX_SERVER_SIZE
-            };
           });
       return Linq4j.asEnumerable(results);
     }
 
-    private Iterator<DiscoveryDruidNode> getDruidServers(DruidNodeDiscoveryProvider druidNodeDiscoveryProvider)
+    /**
+     * Returns a row for all node types which don't serve data. The returned row contains only static information.
+     */
+    private static Object[] buildRowForNonDataServer(DiscoveryDruidNode discoveryDruidNode)
+    {
+      final DruidNode node = discoveryDruidNode.getDruidNode();
+      return new Object[]{
+          node.getHostAndPortToUse(),
+          node.getHost(),
+          (long) node.getPlaintextPort(),
+          (long) node.getTlsPort(),
+          StringUtils.toLowerCase(discoveryDruidNode.getNodeRole().toString()),
+          null,
+          UNKNOWN_SIZE,
+          UNKNOWN_SIZE
+      };
+    }
+
+    /**
+     * Returns a row for discoverable data server. This method prefers the information from
+     * {@code serverFromInventoryView} if available which is the current state of the server. Otherwise, it
+     * will get the information from {@code discoveryDruidNode} which has only static configurations.
+     */
+    private static Object[] buildRowForDiscoverableDataServer(
+        DiscoveryDruidNode discoveryDruidNode,
+        @Nullable DruidServer serverFromInventoryView
+    )
+    {
+      final DruidNode node = discoveryDruidNode.getDruidNode();
+      final DruidServer druidServerToUse = serverFromInventoryView == null
+                                           ? toDruidServer(discoveryDruidNode)
+                                           : serverFromInventoryView;
+      final long currentSize;
+      if (serverFromInventoryView == null) {
+        // If server is missing in serverInventoryView, the currentSize should be unknown
+        currentSize = UNKNOWN_SIZE;
+      } else {
+        currentSize = serverFromInventoryView.getCurrSize();
+      }
+      return new Object[]{
+          node.getHostAndPortToUse(),
+          node.getHost(),
+          (long) node.getPlaintextPort(),
+          (long) node.getTlsPort(),
+          StringUtils.toLowerCase(discoveryDruidNode.getNodeRole().toString()),
+          druidServerToUse.getTier(),
+          currentSize,
+          druidServerToUse.getMaxSize()
+      };
+    }
+
+    private static boolean isDiscoverableDataServer(DiscoveryDruidNode druidNode)
+    {
+      final DruidService druidService = druidNode.getServices().get(DataNodeService.DISCOVERY_SERVICE_KEY);
+      if (druidService == null) {
+        return false;
+      }
+      final DataNodeService dataNodeService = (DataNodeService) druidService;
+      return dataNodeService.isDiscoverable();
+    }
+
+    private static DruidServer toDruidServer(DiscoveryDruidNode discoveryDruidNode)
+    {
+      if (isDiscoverableDataServer(discoveryDruidNode)) {
+        final DruidNode druidNode = discoveryDruidNode.getDruidNode();
+        final DataNodeService dataNodeService = (DataNodeService) discoveryDruidNode
+            .getServices()
+            .get(DataNodeService.DISCOVERY_SERVICE_KEY);
+        return new DruidServer(
+            druidNode.getHostAndPortToUse(),
+            druidNode.getHostAndPort(),
+            druidNode.getHostAndTlsPort(),
+            dataNodeService.getMaxSize(),
+            dataNodeService.getType(),
+            dataNodeService.getTier(),
+            dataNodeService.getPriority()
+        );
+      } else {
+        throw new ISE("[%s] is not a discoverable data server", discoveryDruidNode);
+      }
+    }
+
+    private static Iterator<DiscoveryDruidNode> getDruidServers(DruidNodeDiscoveryProvider druidNodeDiscoveryProvider)
     {
       return Arrays.stream(NodeRole.values())
                    .flatMap(nodeRole -> druidNodeDiscoveryProvider.getForNodeRole(nodeRole).getAllNodes().stream())
@@ -554,9 +639,10 @@ public class SystemSchema extends AbstractSchema
     @Override
     public Enumerable<Object[]> scan(DataContext root)
     {
-      final AuthenticationResult authenticationResult =
-          (AuthenticationResult) root.get(PlannerContext.DATA_CTX_AUTHENTICATION_RESULT);
-
+      final AuthenticationResult authenticationResult = (AuthenticationResult) Preconditions.checkNotNull(
+          root.get(PlannerContext.DATA_CTX_AUTHENTICATION_RESULT),
+          "authenticationResult in dataContext"
+      );
       checkStateReadAccessForServers(authenticationResult, authorizerMapper);
 
       final List<Object[]> rows = new ArrayList<>();
@@ -643,9 +729,10 @@ public class SystemSchema extends AbstractSchema
             public Object[] current()
             {
               final TaskStatusPlus task = it.next();
-              final String hostAndPort;
+              @Nullable final String host = task.getLocation().getHost();
+              @Nullable final String hostAndPort;
 
-              if (task.getLocation().getHost() == null) {
+              if (host == null) {
                 hostAndPort = null;
               } else {
                 final int port;
@@ -655,7 +742,7 @@ public class SystemSchema extends AbstractSchema
                   port = task.getLocation().getPort();
                 }
 
-                hostAndPort = HostAndPort.fromParts(task.getLocation().getHost(), port).toString();
+                hostAndPort = HostAndPort.fromParts(host, port).toString();
               }
               return new Object[]{
                   task.getId(),
@@ -668,7 +755,7 @@ public class SystemSchema extends AbstractSchema
                   toStringOrNull(task.getRunnerStatusCode()),
                   task.getDuration() == null ? 0L : task.getDuration(),
                   hostAndPort,
-                  task.getLocation().getHost(),
+                  host,
                   (long) task.getLocation().getPort(),
                   (long) task.getLocation().getTlsPort(),
                   task.getErrorMsg()
@@ -709,8 +796,10 @@ public class SystemSchema extends AbstractSchema
         DataContext root
     )
     {
-      final AuthenticationResult authenticationResult =
-          (AuthenticationResult) root.get(PlannerContext.DATA_CTX_AUTHENTICATION_RESULT);
+      final AuthenticationResult authenticationResult = (AuthenticationResult) Preconditions.checkNotNull(
+          root.get(PlannerContext.DATA_CTX_AUTHENTICATION_RESULT),
+          "authenticationResult in dataContext"
+      );
 
       Function<TaskStatusPlus, Iterable<ResourceAction>> raGenerator = task -> Collections.singletonList(
           AuthorizationUtils.DATASOURCE_READ_RA_GENERATOR.apply(task.getDataSource()));
@@ -873,8 +962,10 @@ public class SystemSchema extends AbstractSchema
         DataContext root
     )
     {
-      final AuthenticationResult authenticationResult =
-          (AuthenticationResult) root.get(PlannerContext.DATA_CTX_AUTHENTICATION_RESULT);
+      final AuthenticationResult authenticationResult = (AuthenticationResult) Preconditions.checkNotNull(
+          root.get(PlannerContext.DATA_CTX_AUTHENTICATION_RESULT),
+          "authenticationResult in dataContext"
+      );
 
       Function<SupervisorStatus, Iterable<ResourceAction>> raGenerator = supervisor -> Collections.singletonList(
           AuthorizationUtils.DATASOURCE_READ_RA_GENERATOR.apply(supervisor.getSource()));
@@ -959,25 +1050,6 @@ public class SystemSchema extends AbstractSchema
         it.close();
       }
     };
-  }
-
-  @Nullable
-  private static String extractHost(@Nullable final String hostAndPort)
-  {
-    if (hostAndPort == null) {
-      return null;
-    }
-
-    return HostAndPort.fromString(hostAndPort).getHostText();
-  }
-
-  private static int extractPort(@Nullable final String hostAndPort)
-  {
-    if (hostAndPort == null) {
-      return -1;
-    }
-
-    return HostAndPort.fromString(hostAndPort).getPortOrDefault(-1);
   }
 
   @Nullable


### PR DESCRIPTION
Backport of #10183 to 0.19.0-iap.