### PR TITLE
IMPLY-4472 hdfs fix

### DIFF
--- a/jenkinsfile
+++ b/jenkinsfile
@@ -540,7 +540,7 @@ def hdfsDeepStorageTests = { stageName, jdkVersion, envMap ->
     integrationTestsWrapper(stageName, jdkVersion, envMap) {
         writeFile file: "${WORKSPACE}/jenkins/hdfs-config", text: "druid_storage_type=hdfs\n" +
             "druid_storage_storageDirectory=/druid/segments\n" +
-            "druid_extensions_loadList=[\"druid-hdfs-storage\",\"druid-orc-extensions\"]\n" +
+            "druid_extensions_loadList=[\"druid-hdfs-storage\"]\n" +
             "druid_indexer_logs_type=hdfs\n" +
             "druid_indexer_logs_directory=/druid/indexing-logs"
         sh script: """

--- a/jenkinsfile
+++ b/jenkinsfile
@@ -540,7 +540,7 @@ def hdfsDeepStorageTests = { stageName, jdkVersion, envMap ->
     integrationTestsWrapper(stageName, jdkVersion, envMap) {
         writeFile file: "${WORKSPACE}/jenkins/hdfs-config", text: "druid_storage_type=hdfs\n" +
             "druid_storage_storageDirectory=/druid/segments\n" +
-            "druid_extensions_loadList=[\"druid-hdfs-storage\", \"druid-parquet-extensions\", \"druid-orc-extensions\"]\n" +
+            "druid_extensions_loadList=[\"druid-hdfs-storage\",\"druid-orc-extensions\"]\n" +
             "druid_indexer_logs_type=hdfs\n" +
             "druid_indexer_logs_directory=/druid/indexing-logs"
         sh script: """


### PR DESCRIPTION
this don't fixes HDFS failing tests because there is another issue with coordinator/historical services

https://ci.qa.imply.io/job/imply-druid/job/druid/job/IMPLY-4472-hdfs-fix/3/artifact/stage__Compile_openjdk8__Run_openjdk11__hdfs_deep_storage_test/logs/coordinator.log

https://ci.qa.imply.io/job/imply-druid/job/druid/job/IMPLY-4472-hdfs-fix/3/artifact/stage__Compile_openjdk8__Run_openjdk11__hdfs_deep_storage_test/logs/historical.log
